### PR TITLE
feature #52: Pagos con volleys

### DIFF
--- a/src/main/java/org/springframework/samples/volleymate/jugador/Jugador.java
+++ b/src/main/java/org/springframework/samples/volleymate/jugador/Jugador.java
@@ -18,6 +18,7 @@ import javax.persistence.Table;
 import javax.validation.constraints.Digits;
 import javax.validation.constraints.NotEmpty;
 
+import javax.validation.constraints.NotNull;
 
 import org.springframework.samples.volleymate.model.Person;
 import org.springframework.samples.volleymate.partido.Partido;
@@ -47,6 +48,10 @@ public class Jugador extends Person{
 
 	@Column(name = "image")
 	protected String image;
+
+	@NotNull
+	@Column(name = "volleys")
+	private Integer volleys;
 
     @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "username", referencedColumnName = "username")

--- a/src/main/java/org/springframework/samples/volleymate/jugador/JugadorController.java
+++ b/src/main/java/org/springframework/samples/volleymate/jugador/JugadorController.java
@@ -119,9 +119,9 @@ public class JugadorController {
     @GetMapping("/jugadores/solicitudes/{partidoId}")
     public String solicitudUnirse(@PathVariable("partidoId") int partidoId, Principal principal, RedirectAttributes redirAttrs){
         Partido partido = this.partidoService.findPartidoById(partidoId);
+        String redirect = String.format("redirect:/partidos/%s", partidoId);
         if(partido == null){
             redirAttrs.addFlashAttribute("mensajeError", "Ups, parece que ha habido un problema!");
-            String redirect = String.format("redirect:/partidos/%s", partidoId);
             return redirect;
         } 
         // Método servicio boolean
@@ -129,13 +129,20 @@ public class JugadorController {
         //////////////////////    
         if(yaTieneSolicitud){
             redirAttrs.addFlashAttribute("mensajeError", "Ya has enviado una solicitud");
-            String redirect = String.format("redirect:/partidos/%s", partidoId);
             return redirect;
         } else {
             Jugador jugador = this.jugadorService.findJugadorByUsername(principal.getName());
-            this.jugadorService.crearSolicitudPartido(jugador, partido);
-            redirAttrs.addFlashAttribute("mensajeExitoso", "Solicitud enviada!");
-            String redirect = String.format("redirect:/partidos/%s", partidoId);
+            String mensaje = "";
+            String value = "";
+            if(jugador.getVolleys()>=partido.getPrecioPersona()){
+                this.jugadorService.crearSolicitudPartido(jugador, partido);
+                mensaje += "mensajeExitoso";
+                value += "Solicitud enviada!";
+            }else{
+                mensaje += "mensajeError";
+                value += "No tienes volleys suficientes. Compralos en nuestra tienda!";
+            }
+            redirAttrs.addFlashAttribute(mensaje, value);
             return redirect;
         }
     }
@@ -155,6 +162,12 @@ public class JugadorController {
             this.jugadorService.unirsePartida(solicitud.getJugador().getId(), solicitud.getPartido().getId());
             redirAttrs.addFlashAttribute("mensajeExitoso", "Enhorabuena, ya estás dentro del partido!");
             this.jugadorService.eliminarSolicitud(solicitud);
+            Jugador jugador = solicitud.getJugador();
+            Partido partido = solicitud.getPartido();
+            Integer volleys = partido.getPrecioPersona();
+            Integer sumVolleys = jugador.getVolleys() - volleys;
+            jugador.setVolleys(sumVolleys);
+            this.jugadorService.saveJugador(jugador);
             /*
                 Aqui que el de frontend que redirija donde este el boton conectado a este controlador, provisionalmente redirige a partidos.
                 ACORDARSE: Hay que mostrar el mensaje en la vista

--- a/src/main/resources/db/hsqldb/data.sql
+++ b/src/main/resources/db/hsqldb/data.sql
@@ -1,19 +1,19 @@
 -- One admin user, named admin1 with passwor 4dm1n and authority admin
 INSERT INTO users(username,password,enabled,correo) VALUES ('admin1','4dm1n',TRUE,'admin@gmail.com');
 INSERT INTO authorities(id,username,authority) VALUES (1,'admin1','admin');
-INSERT INTO jugadores VALUES (2,'Admin','Admin','Sevilla','','MASCULINO','666666666','admin1');
+INSERT INTO jugadores(id, first_name, last_name, ciudad, telephone, sexo, image, username, volleys) VALUES (2,'Admin','Admin','Sevilla','666666666','MASCULINO','','admin1', 10000000);
 
 INSERT INTO users(username,password,enabled,correo) VALUES ('jorsilman','jorsilman',TRUE,'jorge@gmail.com');
 INSERT INTO authorities(id,username,authority) VALUES (2,'jorsilman','admin');
-INSERT INTO jugadores VALUES (1,'Jorge','Sillero','Sevilla','https://st1.uvnimg.com/e0/40/ab16af48465f804d56e0c2a7ccf4/gettyimages-1240189250.jpg','MASCULINO','657236154','jorsilman');
+INSERT INTO jugadores(id, first_name, last_name, ciudad, telephone, sexo, image, username, volleys) VALUES (1,'Jorge','Sillero','Sevilla','657236154','MASCULINO','https://st1.uvnimg.com/e0/40/ab16af48465f804d56e0c2a7ccf4/gettyimages-1240189250.jpg','jorsilman', 1000);
 
 INSERT INTO users(username,password,enabled,correo) VALUES ('barba','barba',TRUE,'barba@gmail.com');
 INSERT INTO authorities(id,username,authority) VALUES (3,'barba','admin');
-INSERT INTO jugadores VALUES (3,'Francisco Javier','Barba','Sevilla','','MASCULINO','666666666','barba');
+INSERT INTO jugadores(id, first_name, last_name, ciudad, telephone, sexo, image, username, volleys) VALUES (3,'Francisco Javier','Barba','Sevilla','666666666','MASCULINO','','barba', 250);
 
 INSERT INTO users(username,password,enabled,correo) VALUES ('paomarsan','paomarsan',TRUE,'paomarsan@gmail.com');
 INSERT INTO authorities(id,username,authority) VALUES (4,'paomarsan','admin');
-INSERT INTO jugadores VALUES (4,'Paola','Martin','Sevilla','','FEMENINO','666666666','paomarsan');
+INSERT INTO jugadores(id, first_name, last_name, ciudad, telephone, sexo, image, username, volleys) VALUES (4,'Paola','Martin','Sevilla','666666666','FEMENINO','','paomarsan', 100);
 
 
 INSERT INTO partidos(id,nombre,sexo,descripcion,tipo,creador,num_jugadores,lugar,fecha,fecha_creacion,precio_persona) VALUES (1,'Partido amistoso','MASCULINO','Vamos a jugar un partido amistoso',0,'jorsilman',3,'Sevilla','2013-01-02 17:00','2013-01-01 17:00',0);


### PR DESCRIPTION
Se ha implementado lo siguiente:
- En el controlador de solicitudUnirse se ha añadido que un jugador que quiera enviar solicitud debe tener como requisito una cantidad de volleys mayor o igual que el precio del partido
- En el controlador de aceptarSolicitud, cuando el creador acepte la solicitud de una persona, se le restará de sus volleys la cantidad que ha pagado por el partido